### PR TITLE
feat: add decode raw func

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -9,7 +9,14 @@ import (
 func Convert(r io.Reader, ps ...plugin) (*bytes.Buffer, error) {
 	// Decode XML document
 	root := &Node{}
-	err := NewDecoder(r, ps...).Decode(root)
+
+	var err error
+	d := NewDecoder(r, ps...)
+	if d.useTokenRaw {
+		err = d.DecodeRaw(root)
+	} else {
+		err = d.Decode(root)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/converter_test.go
+++ b/converter_test.go
@@ -1,6 +1,7 @@
 package xml2json
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -235,6 +236,35 @@ func TestXMLSequence(t *testing.T) {
 
 	assert.JSONEq(jsnExpr, res.String())
 
+}
+
+func TestUseTokenRaw(t *testing.T) {
+	assert := assert.New(t)
+
+	s := `<a:root xmlns:a="http://web.site/">
+			<b:header xmlns:b="http://web.site/"/>
+			<a:body>
+				<a:sample>example</a:sample>
+			</a:body>
+		</a:bad>`
+
+	js, err := Convert(strings.NewReader(s), WithAttrPrefix("-"), IncludeNSPrefix(true), UseRawToken(false))
+	assert.NoError(err)
+
+	fmt.Println(js.String())
+
+	jsExpected := `{
+		"a:root": {
+			"-a": "http://web.site/",
+			"b:header": {
+				"-b": "http://web.site/"
+			},
+			"a:body": {
+				"a:sample": "example"
+			}
+		}
+	}`
+	assert.JSONEq(jsExpected, js.String())
 }
 
 func TestConvertWithNSPrefix(t *testing.T) {

--- a/converter_test.go
+++ b/converter_test.go
@@ -1,7 +1,6 @@
 package xml2json
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -246,12 +245,10 @@ func TestUseTokenRaw(t *testing.T) {
 			<a:body>
 				<a:sample>example</a:sample>
 			</a:body>
-		</a:bad>`
+		</a:root>`
 
-	js, err := Convert(strings.NewReader(s), WithAttrPrefix("-"), IncludeNSPrefix(true), UseRawToken(false))
+	js, err := Convert(strings.NewReader(s), WithAttrPrefix("-"), IncludeNSPrefix(true), UseRawToken(true))
 	assert.NoError(err)
-
-	fmt.Println(js.String())
 
 	jsExpected := `{
 		"a:root": {

--- a/decoder.go
+++ b/decoder.go
@@ -24,6 +24,7 @@ type Decoder struct {
 	sequencePrefix     string
 	nsPrefix           string
 	includeNSPrefix    bool
+	useTokenRaw        bool
 	excludeAttrs       map[string]bool
 	formatters         []nodeFormatter
 	NameSpacePrefix    map[string]string
@@ -136,7 +137,78 @@ func (dec *Decoder) Decode(root *Node) error {
 					elem.label = prefix + ":" + se.Name.Local
 				}
 			}
-			
+
+			if dec.includeXMLSequence {
+				elem.n.AddChild(dec.sequencePrefix+"sequence", &Node{Data: strconv.Itoa(elem.sequence)})
+			}
+		case xml.CharData:
+			// Extract XML data (if any)
+			elem.n.Data = trimNonGraphic(string(xml.CharData(se)))
+		case xml.EndElement:
+			dec.levelSequence = dec.levelSequence[:len(dec.levelSequence)-1]
+			// And add it to its parent list
+			if elem.parent != nil {
+				elem.parent.n.AddChild(elem.label, elem.n)
+			}
+
+			// Then change the current element to its parent
+			elem = elem.parent
+		}
+	}
+
+	for _, formatter := range dec.formatters {
+		formatter.Format(root)
+	}
+
+	return nil
+}
+
+// DecodeRaw acts the same as Decode, but uses Decoder.RawToken instead.
+// RawToken does not verify that start and end elements match, and,
+// crucially, does not translate namespace prefixes to their corresponding URL.
+// This is good for including the prefix in the resulting JSON.
+func (dec *Decoder) DecodeRaw(root *Node) error {
+	xmlDec := xml.NewDecoder(dec.r)
+
+	// That will convert the charset if the provided XML is non-UTF-8
+	xmlDec.CharsetReader = charset.NewReaderLabel
+
+	// Create first element from the root node
+	elem := &element{
+		parent: nil,
+		n:      root,
+	}
+	dec.levelSequence = append(dec.levelSequence, 1)
+
+	for {
+		t, _ := xmlDec.RawToken()
+		if t == nil {
+			break
+		}
+		switch se := t.(type) {
+		case xml.StartElement:
+			// Build new a new current element and link it to its parent
+			elem = &element{
+				parent:   elem,
+				n:        &Node{},
+				label:    se.Name.Local,
+				sequence: dec.levelSequence[len(dec.levelSequence)-1],
+			}
+			dec.levelSequence[len(dec.levelSequence)-1]++
+			dec.levelSequence = append(dec.levelSequence, 1)
+
+			// Extract attributes as children
+			for _, a := range se.Attr {
+				if _, ok := dec.excludeAttrs[a.Name.Local]; ok {
+					continue
+				}
+				elem.n.AddChild(dec.attributePrefix+a.Name.Local, &Node{Data: a.Value})
+			}
+
+			if se.Name.Space != "" && dec.includeNSPrefix {
+				elem.label = se.Name.Space + ":" + se.Name.Local
+			}
+
 			if dec.includeXMLSequence {
 				elem.n.AddChild(dec.sequencePrefix+"sequence", &Node{Data: strconv.Itoa(elem.sequence)})
 			}

--- a/plugins.go
+++ b/plugins.go
@@ -28,6 +28,8 @@ type (
 
 	includeXMLSequence bool
 
+	useRawToken bool
+
 	excluder []string
 
 	nodesFormatter struct {
@@ -99,6 +101,11 @@ func IncludeNSPrefix(v bool) *includeNSPrefix {
 func IncludeXMLSequence(v bool) *includeXMLSequence {
 	seq := includeXMLSequence(v)
 	return &seq
+}
+
+func UseRawToken(v bool) *useRawToken {
+	raw := useRawToken(v)
+	return &raw
 }
 
 func (a *attrPrefixer) AddToEncoder(e *Encoder) *Encoder {
@@ -190,6 +197,15 @@ func (i *includeXMLSequence) AddToEncoder(e *Encoder) *Encoder {
 
 func (i *includeXMLSequence) AddToDecoder(d *Decoder) *Decoder {
 	d.includeXMLSequence = bool(*i)
+	return d
+}
+
+func (u *useRawToken) AddToEncoder(e *Encoder) *Encoder {
+	return e
+}
+
+func (u *useRawToken) AddToDecoder(d *Decoder) *Decoder {
+	d.useTokenRaw = bool(*u)
 	return d
 }
 


### PR DESCRIPTION
## Problem
When converting an XML document that has multiple namespaces that reference the same URI, the prefix gets overridden and is incorrectly used for subsequent nodes.

[go.dev/play example](https://go.dev/play/p/BdFbvpDXL5I)

For example, given the following XML, where `xmlns:a` and `xmlns:b` both point to `http://web.site/`:
```xml
<a:root xmlns:a="http://web.site/">
	<b:header xmlns:b="http://web.site/"/>
	<a:body>
		<a:sample>example</a:sample>
	</a:body>
</a:root>
```

when we convert this XML, we get the following JSON:
```json
{
    "a:root": {
        "-a": "http://web.site/",
        "b:header": {
            "-b": "http://web.site/"
        },
        "b:body": {
            "b:sample": "example"
        }
    }
}
```

We should see `a:body` and `a:sample`, since the `b` namespace is scoped to `header`. Instead, it's `b:body` and `b:sample`.

## Analysis
This is because when `Decode` registers the `xmlns` prefixes, [it uses the URI as a key in a map `NameSpacePrefix`, with the value being the prefix](https://github.com/identitii/goxml2json/blob/master/decoder.go#L123-L125). e.g. when processing the node `<a:root xmlns:a="http://web.site/">`, the map would be `http://web.site/ -> a`. This entry in the map gets updated when processing the next node `<b:header xmlns:b="http://web.site/"/>`. The map would now be `http://web.site/ -> b`.

`xmlns` is a special attribute for XML documents. Go's encoding/xml [`Decoder.Token`](https://github.com/golang/go/blob/master/src/encoding/xml/xml.go#L274) saves a given node's `xmlns` in [its own namespace map](https://github.com/golang/go/blob/master/src/encoding/xml/xml.go#L210) where instead, [the prefix is the key, and the URI is the value](https://github.com/golang/go/blob/master/src/encoding/xml/xml.go#L310). The map is not made available to the user, but it is used to determine which namespace is currently in scope for a given node, which *is* made available under `StartElement.Name`'s `Space` and `Local` variables. However, `StartElement.Name` [goes through a 'translation' step](https://github.com/golang/go/blob/master/src/encoding/xml/xml.go#L345-L361) before being returned, whereby `Space` is updated from the prefix to the URI. This means that, ultimately, the prefix is not readily available for the user to use.

<img width="1451" height="357" alt="image" src="https://github.com/user-attachments/assets/60f92af4-2b02-4434-93ae-7126710a1f0a" />

## Proposed Solution
Alongside `Decoder.Token` is [`Decoder.RawToken`](https://github.com/golang/go/blob/master/src/encoding/xml/xml.go#L544), which "is like `Decoder.Token` but does not verify that start and end elements match and **does not translate name space prefixes to their corresponding URLs**." Utilising `RawToken` instead of `Token` means we have access to the prefix under `StartElement.Name.Space`, and also means we don't have to use a map to save the prefixes that get defined; they're managed by `encoding/xml` through the aforementioned namespace map.

The proposed change removes the need for the namespace prefix map, as the prefix is now available under `se.Name.Space`. The change also retains adding the prefix-to-URI child node to the element whilst looping through the attributes.

When converting the example XML above with this change, we get the following JSON:
```json
{
    "a:root": {
        "-a": "http://web.site/",
        "b:header": {
            "-b": "http://web.site/"
        },
        "a:body": {
            "a:sample": "example"
        }
    }
}
```

However, some validation is lost by using `RawToken`, namely, the check that the StartElement and EndElement match. For example, the following XML also produces the same JSON:
```xml
<a:root xmlns:a="http://web.site/">
	<b:header xmlns:b="http://web.site/"/>
	<a:body>
		<a:sample>example</a:sample>
	</a:body>
</a:roooooooooooooot>
```

Which is why I opted to introduce a new func, separate from the existing functionality. It can be enabled using an option (plugin) when setting up a new Decoder or Converter:

```go
dec := NewDecoder(strings.NewReader(input), WithAttrPrefix("-"), IncludeNSPrefix(true), UseRawToken(true))
```